### PR TITLE
fix(argocd-apps): Changed the project field of the applicationset from a tpl to str(#1978)

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for managing additional Argo CD Applications and Projects
 type: application
-version: 0.0.9
+version: 1.0.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -14,5 +14,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Multiple sources for Application and ApplicationSet
+    - kind: fixed
+      description: Changed the project field of the applicationset from a tpl function to a string.

--- a/charts/argocd-apps/ci/applicationsets-values.yaml
+++ b/charts/argocd-apps/ci/applicationsets-values.yaml
@@ -42,3 +42,32 @@ applicationsets:
   syncPolicy:
     # Set Application finalizer
     preserveResourcesOnDeletion: false
+- name: applicationset-list-generator
+  generators:
+  - list:
+      elements:
+        - cluster: engineering-dev
+          url: https://kubernetes.default.svc
+      template:
+        metadata: {}
+        spec:
+          project: '{{cluster}}'
+          source:
+            targetRevision: HEAD
+            repoURL: https://github.com/argoproj/argo-cd.git
+            # New path value is generated here:
+            path: 'applicationset/examples/template-override/{{cluster}}-override'
+          destination: {}
+  template:
+    metadata:
+      name: '{{cluster}}-guestbook'
+    spec:
+      project: '{{cluster}}'
+      source:
+        repoURL: https://github.com/argoproj/argo-cd.git
+        targetRevision: HEAD
+        # This 'default' value is not used: it is is replaced by the generator's template path, above
+        path: applicationset/examples/template-override/default
+      destination:
+        server: '{{url}}'
+        namespace: guestbook

--- a/charts/argocd-apps/templates/applicationsets.yaml
+++ b/charts/argocd-apps/templates/applicationsets.yaml
@@ -51,7 +51,7 @@ spec:
     {{- end }}
     {{- with .spec }}
     spec:
-      project: {{ tpl .project $ }}
+      project: {{ .project | squote }}
       {{- with .source }}
       source:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
- In ApplicationSet, I see no rational reason why project fields should be templated with the tpl function.
- Raised major version due to possible backward incompatibility.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
